### PR TITLE
"add key-bind for system monitor `btop` "

### DIFF
--- a/dotconfig/hypr/hyprland.conf
+++ b/dotconfig/hypr/hyprland.conf
@@ -163,6 +163,7 @@ bind = SUPER, E, exec, thunar
 bind = SUPER, R, exec, killall rofi || rofi -show drun -theme ~/.config/rofi/global/rofi.rasi
 bind = SUPER, period, exec, killall rofi || rofi -show emoji -emoji-format "{emoji}" -modi emoji -theme ~/.config/rofi/global/emoji
 bind = SUPER, escape, exec, wlogout --protocol layer-shell -b 5 -T 400 -B 400
+bind = SUPER, H, exec, kitty -e btop #change Terminal name with your choice(alacritty/kitty).
 
 # █░█░█ █ █▄░█ █▀▄ █▀█ █░█░█   █▀▄▀█ ▄▀█ █▄░█ ▄▀█ █▀▀ █▀▄▀█ █▀▀ █▄░█ ▀█▀
 # ▀▄▀▄▀ █ █░▀█ █▄▀ █▄█ ▀▄▀▄▀   █░▀░█ █▀█ █░▀█ █▀█ █▄█ █░▀░█ ██▄ █░▀█ ░█░


### PR DESCRIPTION
Resource monitor that shows usage and stats for processor, memory, disks, network and processes.