### PR TITLE
Dynamic Monitor Setup & Keyboard Audio Keybind

### DIFF
--- a/dotconfig/hypr/hyprland.conf
+++ b/dotconfig/hypr/hyprland.conf
@@ -11,7 +11,7 @@ exec-once = waybar
 
 # █▀▄▀█ █▀█ █▄░█ █ ▀█▀ █▀█ █▀█
 # █░▀░█ █▄█ █░▀█ █ ░█░ █▄█ █▀▄
-monitor = ,1920x1080@60,0x0,1
+monitor=,preferred,auto,1
 
 # █ █▄░█ █▀█ █░█ ▀█▀
 # █ █░▀█ █▀▀ █▄█ ░█░
@@ -145,6 +145,16 @@ bind = SUPER, B, exec, brave
 bind = SUPER, L, exec, /home/titus/w11
 bind = SUPER, P, exec, wlogout
 bind = SUPER, F1, exec, ~/.config/hypr/keybind
+
+# █▀▄▀█ █░█ █░░ ▀█▀ █ █▀▄▀█ █▀▀ █▀▄ █ ▄▀█
+# █░▀░█ █▄█ █▄▄ ░█░ █ █░▀░█ ██▄ █▄▀ █ █▀█
+binde=, XF86AudioRaiseVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+
+binde=, XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
+binde=, XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
+bind=, XF86AudioPlay, exec, playerctl play-pause
+bind=, XF86AudioPause, exec, playerctl play-pause
+bind=, XF86AudioNext, exec, playerctl next
+bind=, XF86AudioPrev, exec, playerctl previous
 
 # █▀ █▀▀ █▀█ █▀▀ █▀▀ █▄░█ █▀ █░█ █▀█ ▀█▀
 # ▄█ █▄▄ █▀▄ ██▄ ██▄ █░▀█ ▄█ █▀█ █▄█ ░█░


### PR DESCRIPTION
Fixed auto configuration for multi-monitors and audio keyboard keybinds:

This is the old one and will not recognize multiple monitors: monitor = ,1920x1080@60,0x0,1

This is the new one:
```sh
monitor=,preferred,auto,1
```

Keyboard audio keybinds (I used this website to generate text art https://fsymbols.com/generators/tarty/):
```sh
# █▀▄▀█ █░█ █░░ ▀█▀ █ █▀▄▀█ █▀▀ █▀▄ █ ▄▀█
# █░▀░█ █▄█ █▄▄ ░█░ █ █░▀░█ ██▄ █▄▀ █ █▀█
binde=, XF86AudioRaiseVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+
binde=, XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
binde=, XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
bind=, XF86AudioPlay, exec, playerctl play-pause
bind=, XF86AudioPause, exec, playerctl play-pause
bind=, XF86AudioNext, exec, playerctl next
bind=, XF86AudioPrev, exec, playerctl previous
```