### PR TITLE
important missing letter

### DIFF
--- a/dotconfig/waybar/config.jsonc
+++ b/dotconfig/waybar/config.jsonc
@@ -1,7 +1,7 @@
 {
     "layer": "top",
     "position": "top",
-    "mod": "dock",
+    "mode": "dock",
     "exclusive": true,
     "passthrough": false,
     "gtk-layer-shell": true,


### PR DESCRIPTION
according to [Waybar's documentation](https://github.com/Alexays/Waybar/wiki/Configuration#bar-config) it should be `mode` and not `mod`